### PR TITLE
feat(contracts): split fees

### DIFF
--- a/contracts/src/MultiproofOracle.sol
+++ b/contracts/src/MultiproofOracle.sol
@@ -22,8 +22,8 @@ contract MultiproofOracle is IMultiproofOracle {
     mapping(bytes32 => ProposalData[]) proposals;
     IProver[] public provers;
 
-    // TODO: Split into separate fees for proof and challenge, if necessary.
-    uint256 public treasuryFeePctWad;
+    uint256 public proverFeePctWad;
+    uint256 public challengedFeePctWad;
     address public treasury;
 
     uint256 public immutable emergencyPauseThreshold;
@@ -43,12 +43,14 @@ contract MultiproofOracle is IMultiproofOracle {
         provers = _provers;
 
         // set params - for details on how to set: https://github.com/zobront/odyssey/blob/multiproof/contracts/spec/params.md
-        require(_args.treasuryFeePctWad < 1e18, "treasury fee must be less than 100%");
+        require(_args.proverFeePctWad < 1e18, "prover fee must be less than 100%");
+        require(_args.challengedFeePctWad < 1e18, "challenged fee must be less than 100%");
         proposalBond = _args.proposalBond;
         challengeTime = _args.challengeTime;
         proofReward = _args.proofReward;
         provingTime = _args.provingTime;
-        treasuryFeePctWad = _args.treasuryFeePctWad;
+        proverFeePctWad = _args.proverFeePctWad;
+        challengedFeePctWad = _args.challengedFeePctWad;
         treasury = _args.treasury;
         emergencyPauseThreshold = _args.emergencyPauseThreshold;
         emergencyPauseTime = _args.emergencyPauseTime;
@@ -128,7 +130,7 @@ contract MultiproofOracle is IMultiproofOracle {
 
         if (successfulProofCount > 0) {
             uint rewards = proofReward * successfulProofCount;
-            uint treasuryFee = rewards * treasuryFeePctWad / 1e18;
+            uint treasuryFee = rewards * proverFeePctWad / 1e18;
             payable(treasury).transfer(treasuryFee);
             payable(msg.sender).transfer(rewards - treasuryFee);
         }
@@ -187,7 +189,7 @@ contract MultiproofOracle is IMultiproofOracle {
 
         proposal.state = ProposalState.Rejected;
 
-        uint treasuryFee = proposalBond * treasuryFeePctWad / 1e18;
+        uint treasuryFee = proposalBond * challengedFeePctWad / 1e18;
         uint proposalBondRewards = proposalBond - treasuryFee;
         uint challangeBondRefund = proofReward * (provers.length - successfulProofCount);
 

--- a/contracts/src/interfaces/IMultiproofOracle.sol
+++ b/contracts/src/interfaces/IMultiproofOracle.sol
@@ -8,7 +8,8 @@ interface IMultiproofOracle {
         uint40 challengeTime;
         uint88 proofReward;
         uint40 provingTime;
-        uint64 treasuryFeePctWad;
+        uint64 proverFeePctWad;
+        uint64 challengedFeePctWad;
         address treasury;
         uint16 emergencyPauseThreshold;
         uint40 emergencyPauseTime;

--- a/contracts/test/MultiproofOracle.t.sol
+++ b/contracts/test/MultiproofOracle.t.sol
@@ -26,7 +26,8 @@ contract MultiproofOracleTest is Test {
             challengeTime: uint40(12 hours),
             proofReward: uint88(1 ether),
             provingTime: uint40(1 days),
-            treasuryFeePctWad: uint64(0.5e18),
+            proverFeePctWad: uint64(0.5e18),
+            challengedFeePctWad: uint64(0.5e18),
             treasury: address(makeAddr("treasury")),
             emergencyPauseThreshold: uint16(200),
             emergencyPauseTime: uint40(10 days)


### PR DESCRIPTION
splits the fees charged into a separate `proverFee` and `challengedFee`, to give deployers more fine grained control over their params