### PR TITLE
feat(contracts): public value encoding handled by verifier

### DIFF
--- a/contracts/src/MultiproofOracle.sol
+++ b/contracts/src/MultiproofOracle.sol
@@ -130,16 +130,14 @@ contract MultiproofOracle is IMultiproofOracle {
                 continue;
             }
 
-            // TODO: We will need to support different public values for each proof type
-            // This probably means different vks, etc, but need to see how those proof systems work
-            PublicValuesStruct memory pvs = PublicValuesStruct({
+            bytes memory pvs = provers[i].encode(PublicValuesStruct({
                 l1BlockHash: l1BlockHash,
                 l2PreRoot: proposal.parent.outputRoot,
                 claimRoot: outputRoot,
                 l2BlockNum: proposal.blockNum,
                 rollupConfigHash: rollupConfigHash,
                 vkey: vkey
-            });
+            }));
 
             // Note: It IS possible to verify valid proofs against invalid parents.
             // Challengers should not challenge proofs of invalid parents, as they will lose their bonds.

--- a/contracts/src/interfaces/IProver.sol
+++ b/contracts/src/interfaces/IProver.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import { IMultiproofOracle } from "./IMultiproofOracle.sol";
+
 interface IProver {
+    function encode(IMultiproofOracle.PublicValuesStruct memory publicValues) external pure returns (bytes memory);
     function verify(bytes memory publicValues, bytes memory proof) external view returns (bool);
 }

--- a/contracts/src/interfaces/IVerifier.sol
+++ b/contracts/src/interfaces/IVerifier.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import { IMultiproofOracle } from "./IMultiproofOracle.sol";
 
-interface IProver {
+interface IVerifier {
     function encode(IMultiproofOracle.PublicValuesStruct memory publicValues) external pure returns (bytes memory);
     function verify(bytes memory publicValues, bytes memory proof) external view returns (bool);
 }

--- a/contracts/src/mocks/MockProver.sol
+++ b/contracts/src/mocks/MockProver.sol
@@ -2,8 +2,13 @@
 pragma solidity ^0.8.13;
 
 import { IProver } from "src/interfaces/IProver.sol";
+import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
 
 contract MockProver is IProver {
+    function encode(IMultiproofOracle.PublicValuesStruct memory publicValues) external pure override returns (bytes memory) {
+        return abi.encode(publicValues);
+    }
+
     function verify(bytes memory publicValues, bytes memory proof) external view returns (bool) {
         if (proof.length == 0) {
             return false;

--- a/contracts/src/mocks/MockProver.sol
+++ b/contracts/src/mocks/MockProver.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import { IProver } from "src/interfaces/IProver.sol";
+import { IVerifier } from "src/interfaces/IVerifier.sol";
 import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
 
-contract MockProver is IProver {
+contract MockProver is IVerifier {
     function encode(IMultiproofOracle.PublicValuesStruct memory publicValues) external pure override returns (bytes memory) {
         return abi.encode(publicValues);
     }

--- a/contracts/test/BaseTest.t.sol
+++ b/contracts/test/BaseTest.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import { MultiproofOracle } from "src/MultiproofOracle.sol";
 import { MockProver } from "src/mocks/MockProver.sol";
-import { IProver } from "src/interfaces/IProver.sol";
+import { IVerifier } from "src/interfaces/IVerifier.sol";
 import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
 import { Test, console } from "forge-std/Test.sol";
 
@@ -12,9 +12,9 @@ contract BaseTest is Test {
     IMultiproofOracle.Challenge public anchor;
 
     function setUp() public {
-        IProver[] memory provers = new IProver[](3);
-        for (uint i = 0; i < provers.length; i++) {
-            provers[i] = IProver(address(new MockProver()));
+        IVerifier[] memory verifiers = new IVerifier[](3);
+        for (uint i = 0; i < verifiers.length; i++) {
+            verifiers[i] = IVerifier(address(new MockProver()));
         }
 
         // set based on defaults here:
@@ -32,7 +32,7 @@ contract BaseTest is Test {
             rollupConfigHash: bytes32(0),
             vkey: bytes32(0)
         });
-        oracle = new MultiproofOracle(provers, 0, bytes32(0), args);
+        oracle = new MultiproofOracle(verifiers, 0, bytes32(0), args);
         vm.deal(address(oracle), 100 ether);
 
         anchor = IMultiproofOracle.Challenge({

--- a/contracts/test/MultiproofOracle.t.sol
+++ b/contracts/test/MultiproofOracle.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { MultiproofOracle } from "src/MultiproofOracle.sol";
 import { MockProver } from "src/mocks/MockProver.sol";
-import { IProver } from "src/interfaces/IProver.sol";
 import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
 import { console } from "forge-std/Test.sol";
 import { BaseTest } from "./BaseTest.t.sol";

--- a/contracts/test/OptimismPortal3.t.sol
+++ b/contracts/test/OptimismPortal3.t.sol
@@ -1,21 +1,21 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+// // SPDX-License-Identifier: UNLICENSED
+// pragma solidity ^0.8.13;
 
-import { MultiproofOracle } from "src/MultiproofOracle.sol";
-import { MockProver } from "src/mocks/MockProver.sol";
-import { IProver } from "src/interfaces/IProver.sol";
-import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
-import { console } from "forge-std/Test.sol";
-import { BaseTest } from "./BaseTest.t.sol";
+// import { MultiproofOracle } from "src/MultiproofOracle.sol";
+// import { MockProver } from "src/mocks/MockProver.sol";
+// import { IProver } from "src/interfaces/IProver.sol";
+// import { IMultiproofOracle } from "src/interfaces/IMultiproofOracle.sol";
+// import { console } from "forge-std/Test.sol";
+// import { BaseTest } from "./BaseTest.t.sol";
 
-contract MultiproofOracleTest is BaseTest {
-    address alice = makeAddr("alice");
-    address bob = makeAddr("bob");
+// contract MultiproofOracleTest is BaseTest {
+//     address alice = makeAddr("alice");
+//     address bob = makeAddr("bob");
 
-    // TODO: write tests of e2e withdrawal
-    // - propose output root
-    // - prove withdrawal
-    // - finalize withdrawal fails
-    // - wait for output root & finalize on oracle
-    // - finalize withdrawal succeed
-}
+//     // TODO: write tests of e2e withdrawal
+//     // - propose output root
+//     // - prove withdrawal
+//     // - finalize withdrawal fails
+//     // - wait for output root & finalize on oracle
+//     // - finalize withdrawal succeed
+// }


### PR DESCRIPTION
each verifier will have a different structure for public values it needs. instead of hardcoding kona's, the MultiproofOracle contract will use a superset of all public values needed, and it'll be the responsibility of the prover to encode it into bytes using the `encode()` function.

note that this means all verifying contracts need to be upgraded with each time new proof systems are added to the MultiproofOracle, but since this can only happen on a full MultiproofOracle contract upgrade, it isn't a big deal to do a few extra deployments and keep them all linked together..